### PR TITLE
Add API to delete gym activity types

### DIFF
--- a/accounts/serializers/activities.py
+++ b/accounts/serializers/activities.py
@@ -41,6 +41,21 @@ class GymActivityTypeResponseSerializer(serializers.ModelSerializer):
         fields = ['id', 'type_name', 'type_description', 'is_active', 'created_on', 'updated_on']
         read_only_fields = ['id', 'created_on', 'updated_on']
 
+
+class GymActivityTypeDeleteSerializer(serializers.Serializer):
+    """Serializer used for deleting multiple activity types by ID"""
+    activity_type_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        allow_empty=False
+    )
+
+    def validate_activity_type_ids(self, value):
+        existing_ids = set(GymActivityType.objects.filter(id__in=value).values_list('id', flat=True))
+        missing_ids = [at_id for at_id in value if at_id not in existing_ids]
+        if missing_ids:
+            raise serializers.ValidationError(f"Activity type ids not found: {missing_ids}")
+        return value
+
 class GymActivityAssignedTrainerSerializer(serializers.ModelSerializer):
     """Serializer for GymActivityAssignedTrainer model"""
     class Meta:

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import ActiveGymMembersView, AddGymMemberView, GymPackageCreateAPIView, GymPackageListAPIView, LoginView, LogoutView,CustomTokenRefreshView, AddGymTrainerView, ActiveGymTrainersView, GymActivityCreateAPIView, GymActivityListAPIView, GymActivityTypeCreateAPIView, GymActivityTypeListAPIView, CheckAuthenticatedView, PaymentCreateAPIView, PaymentUpdateAPIView, PaymentDeleteAPIView, PaymentListAPIView,DashboardAPIView
+from .views import ActiveGymMembersView, AddGymMemberView, GymPackageCreateAPIView, GymPackageListAPIView, LoginView, LogoutView,CustomTokenRefreshView, AddGymTrainerView, ActiveGymTrainersView, GymActivityCreateAPIView, GymActivityListAPIView, GymActivityTypeCreateAPIView, GymActivityTypeListAPIView, GymActivityTypeDeleteAPIView, CheckAuthenticatedView, PaymentCreateAPIView, PaymentUpdateAPIView, PaymentDeleteAPIView, PaymentListAPIView,DashboardAPIView
  
 urlpatterns = [
     path('login/', LoginView.as_view()),
@@ -34,6 +34,7 @@ urlpatterns = [
 
     # View list of all gym activity types
     path('gym/activity/types/', GymActivityTypeListAPIView.as_view(), name='gym_activity_type_list'),
+    path('gym/activity/type/delete/', GymActivityTypeDeleteAPIView.as_view(), name='delete_gym_activity_type'),
 
     path('gym/check-authenticated/', CheckAuthenticatedView.as_view(), name='check_authenticated'),
 

--- a/accounts/views/activities.py
+++ b/accounts/views/activities.py
@@ -13,6 +13,7 @@ from accounts.serializers import (
     GymActivityCreateSerializer,
     GymActivityListSerializer,
     GymActivityTypeResponseSerializer,
+    GymActivityTypeDeleteSerializer,
 )
 
 
@@ -150,3 +151,21 @@ class GymActivityListAPIView(generics.ListAPIView):
             'count': queryset.count(),
             'data': serializer.data
         })
+
+
+@extend_schema(
+    request=GymActivityTypeDeleteSerializer,
+    responses={204: None},
+    description="Delete gym activity types by IDs. Corresponding activities will have their activity_type field set to null."
+)
+class GymActivityTypeDeleteAPIView(APIView):
+    permission_classes = [IsAuthenticatedViaLoginSession, IsGymOwnerOrStaff, IsCheckUserActive]
+
+    @transaction.atomic
+    def delete(self, request):
+        serializer = GymActivityTypeDeleteSerializer(data=request.data)
+        if serializer.is_valid():
+            ids = serializer.validated_data['activity_type_ids']
+            GymActivityType.objects.filter(id__in=ids).delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary
- add `GymActivityTypeDeleteSerializer` for bulk deletion of activity types
- implement `GymActivityTypeDeleteAPIView`
- wire new view in `accounts/urls.py`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68851525631c8322a1511b9ae5e0520e